### PR TITLE
fix: send missing firstname and lastname variables to database

### DIFF
--- a/services/auth-service/src/auth/service/auth.service.ts
+++ b/services/auth-service/src/auth/service/auth.service.ts
@@ -24,6 +24,8 @@ export class AuthService {
   public async register({
     email,
     password,
+    firstname,
+    lastname,
   }: RegisterRequestDto): Promise<RegisterResponse> {
     let user = await this.userRepository.findByEmail(email);
 
@@ -40,8 +42,8 @@ export class AuthService {
       id: uuid(),
       email,
       password: encodedPassword,
-      firstName: '',
-      lastName: '',
+      firstName: firstname,
+      lastName: lastname,
       role: 'user',
     });
     const token: string = this.jwtService.generateToken(createdUser);

--- a/services/auth-service/src/auth/user-repository.ts
+++ b/services/auth-service/src/auth/user-repository.ts
@@ -29,7 +29,13 @@ export class UserRepository {
 
   public create(data: CreateUserArgs) {
     return this.prismaService.user.create({
-      data,
+      data: {
+        id: data.id,
+        email: data.email,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        password: data.password,
+      },
     });
   }
 


### PR DESCRIPTION
I added missing `firstname` and `lastname` variables to register request. Also, I fixed data type error inside of `user repository`.